### PR TITLE
Custom matchers

### DIFF
--- a/spec/crawler_spec.rb
+++ b/spec/crawler_spec.rb
@@ -11,9 +11,10 @@ RSpec.describe Crawler do
   describe '#check_content' do
     context 'when context is not empty' do
       let(:content) { 'not empty' }
+      let(:result) { Dummy.new.check_content(content) }
 
       it 'returns the contents' do
-        expect(Dummy.new.check_content(content)).to eq(content)
+        expect(result).not_to be_empty(content)
       end
     end
 
@@ -42,7 +43,7 @@ RSpec.describe Crawler do
       end
 
       it 'returns an html payload' do
-        expect(response.css('p').text).to eq('Hi')
+        expect(response.css('p').text).to have_content_with_text('Hi')
       end
     end
 
@@ -61,7 +62,7 @@ RSpec.describe Crawler do
       end
 
       it 'returns a json payload' do
-        expect(response['greeting']).to eq('Hi')
+        expect(response['greeting']).to have_content_with_text('Hi')
       end
     end
   end

--- a/spec/integration/crawler_spec.rb
+++ b/spec/integration/crawler_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module CrawlerMatchers
+  def have_content_with_text(text)
+    eq(text)
+  end
+
+  def be_empty(text)
+    eq(text.empty?)
+  end
+end

--- a/spec/integration/sources/source_spec.rb
+++ b/spec/integration/sources/source_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module SourceMatchers
+  def contain_content_matching(pattern)
+    include(match(/#{pattern}/i))
+  end
+
+  def puts_to_stdout(text)
+    output(text).to_stdout
+  end
+end

--- a/spec/sources/az_lyrics_spec.rb
+++ b/spec/sources/az_lyrics_spec.rb
@@ -22,7 +22,7 @@ describe Sources::AZLyrics do
       end
 
       it 'returns the correct lyrics' do
-        expect(response).to include(match(/I need somebody/i))
+        expect(response).to contain_content_matching('Help me if you can, I\'m feeling down')
       end
     end
   end

--- a/spec/sources/genius_spec.rb
+++ b/spec/sources/genius_spec.rb
@@ -24,7 +24,7 @@ describe Sources::Genius do
       end
 
       it 'returns the song url' do
-        expect { response.fetch_song_url }.to output(/Help!/i).to_stdout
+        expect { response.fetch_song_url }.to puts_to_stdout(/Help!/i)
       end
     end
   end

--- a/spec/sources/lyrics_freak_spec.rb
+++ b/spec/sources/lyrics_freak_spec.rb
@@ -24,7 +24,7 @@ describe Sources::LyricsFreak do
       end
 
       it 'returns the song url' do
-        expect { response.fetch_lyrics }.to output(/Help!/i).to_stdout
+        expect { response.fetch_lyrics }.to puts_to_stdout(/Help!/i)
       end
     end
   end

--- a/spec/sources/source_spec.rb
+++ b/spec/sources/source_spec.rb
@@ -7,7 +7,7 @@ describe Sources::Source do
   let(:dummy) { Class.new.extend(described_class) }
 
   specify '#spoof_user_agent' do
-    expect(dummy.spoof_user_agent).to include(match(/User-agent/i))
+    expect(dummy.spoof_user_agent).to contain_content_matching('User-Agent')
   end
 
   describe '#split_newline' do
@@ -27,7 +27,7 @@ describe Sources::Source do
       let(:line_size) { text.length / 2 }
 
       it 'will break it in line_number chars each line' do
-        expect { dummy.text_splitter(text, line_size) }.to output("I am\nthe\nWalrus\n").to_stdout
+        expect { dummy.text_splitter(text, line_size) }.to puts_to_stdout("I am\nthe\nWalrus\n")
       end
     end
   end
@@ -38,7 +38,7 @@ describe Sources::Source do
       let(:text) { "Hello Goodbye\n" }
 
       it 'will output each item to stdout' do
-        expect { dummy.display_lyrics(string_array) }.to output(text).to_stdout
+        expect { dummy.display_lyrics(string_array) }.to puts_to_stdout(text)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'webmock/rspec'
 require 'integration/crawler_spec'
+require 'integration/sources/source_spec'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -14,5 +15,6 @@ end
 RSpec.configure do |c|
   c.silence_filter_announcements = true
   c.include CrawlerMatchers
+  c.include SourceMatchers
   # c.before { allow($stdout).to receive(:puts) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'webmock/rspec'
+require 'integration/crawler_spec'
 
 WebMock.disable_net_connect!(allow_localhost: true)
 
@@ -12,5 +13,6 @@ end
 
 RSpec.configure do |c|
   c.silence_filter_announcements = true
+  c.include CrawlerMatchers
   # c.before { allow($stdout).to receive(:puts) }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'webmock/rspec'
+
 WebMock.disable_net_connect!(allow_localhost: true)
 
 RSPEC_ROOT = File.dirname __FILE__


### PR DESCRIPTION
Neat feature, actually. Instead of using the standard `RSpec` matchers, we combine those to create matchers that talk the language of our app. 